### PR TITLE
Fixes exit code validation for scenarios where the child process crashes

### DIFF
--- a/lib/monitor.js
+++ b/lib/monitor.js
@@ -132,10 +132,12 @@ module.exports = function monit (worker, debug, fork) {
     }, ms('2s'));
   }, ms('30s'));
 
-  proc.once('exit', function (code) {
-    //This handler exits the master process only if the child exited with code != 1.
+  proc.once('exit', function (code, signal) {
+    //This handler exits the master process only if the child exited with code !== 0.
     //Ignore this handler if the process is killed or stopped.
-    if (code) {
+    if (code!==0) {
+      //When child crashes (Out of memory) exit code is null so we log information to register if it crashed or not
+      debug("Child process exited with code: " + code + " signaled: " + signal  + ". Stopping master process");
       process.exit(code);
     }
   });

--- a/test/basic.tests.js
+++ b/test/basic.tests.js
@@ -55,11 +55,20 @@ describe('master-process', function () {
     });
   });
 
-  it('should crash the master process when the worker crash', function (done) {
+  it('should exit the master process when the worker exits with code !== 0', function (done) {
     proc.once('listening', function () {
       request.get('http://localhost:9898/crash').on('error', _.noop);
     }).once('exit', function (code) {
       assert.equal(code, 1);
+      done();
+    });
+  });
+
+  it('should exit the master process when the worker crash', function (done) {
+    proc.once('listening', function () {
+      request.get('http://localhost:9898/hardcrash').on('error', _.noop);
+    }).once('exit', function (code, signal) {
+      assert.equal(code, 0);
       done();
     });
   });

--- a/test/fixture/server.js
+++ b/test/fixture/server.js
@@ -17,6 +17,12 @@ var server = http.createServer(function(req, res) {
   if (req.url === '/crash') {
     return process.exit(1);
   }
+
+  if (req.url === '/hardcrash') {
+    var root= [];
+    while(true) root.push(new Array(10000));
+  }
+
   res.writeHead(200);
   res.end(worker_index.toString());
 });
@@ -27,6 +33,7 @@ server.listen(9898, function (err) {
     return process.exit(1);
   }
   console.log('listening');
+  process.send({listening:true});
 });
 
 process.once('SIGTERM', function () {


### PR DESCRIPTION
When a child process crashes because of an operational problem (Out of memory) the exit code is null and the parent process is never terminated. The fix adds validation to avoid that case and also adds a log to register the exit code and the signal received by the child process.