### PR TITLE
Try to kill worker with SIGTERM, then send SIGKILL

### DIFF
--- a/lib/monitor.js
+++ b/lib/monitor.js
@@ -32,6 +32,7 @@ module.exports = function monit (worker, debug, fork) {
   var max_mem_failures = parseInt(process.env.MEM_MONITOR_FAILURES, 10) || 10;
   var max_cpu_failures = parseInt(process.env.CPU_MONITOR_FAILURES, 10) || 10;
   var max_memory = DEFAULT_MAX_MEMORY;
+  var max_kill_timeout = parseInt(process.env.MAX_KILL_TIMEOUT, 10) || 5000;
 
   if (process.env.MAX_MEMORY_ALLOWED_MB &&
     parseInt(process.env.MAX_MEMORY_ALLOWED_MB, 10) > 0){
@@ -52,8 +53,17 @@ module.exports = function monit (worker, debug, fork) {
         new_pid: new_worker.process.pid
       }));
 
-      debug('force kill ' + proc.pid);
-      process.kill(proc.pid, 'SIGKILL');
+      process.kill(proc.pid, 'SIGTERM');
+      // after trying SIGTERM, there is a chance it won't work, so
+      // we call SIGKILL to ensure it dies
+      setTimeout(function () {
+        try {
+          process.kill(proc.pid, 'SIGKILL');
+          debug('trying to force kill ' + proc.pid);
+        } catch(e) {
+          debug('proc ' + proc.pid + ' is already dead or can\'t be killed');
+        }
+      }, max_kill_timeout);
     });
   };
 


### PR DESCRIPTION
The idea here is to try to gracefully kill the worker process first, and after a timeout use SIGKILL (which will error out if the process doesn't exist, which we log and move on).