### PR TITLE
DX-106: Update debug library version to 2.6.9 and ms to 2.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: "node_js"
 node_js:
-  - "0.10"
-  - "0.12"
   - "4"
+  - "6"
+  - "8"
 env:
   - CXX=g++-4.8
 addons:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "master-process",
   "description": "Reload your application with no downtime.",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "author": "José F. Romaniello <jfromaniello@gmail.com> (http://joseoncode.com)",
   "repository": {
     "url": "git://github.com/jfromaniello/master-process.git"
@@ -13,7 +13,7 @@
   "dependencies": {
     "async": "~1.4.2",
     "bytes": "^2.2.0",
-    "debug": "~2.2.0",
+    "debug": "~2.6.9",
     "keypress": "~0.2.1",
     "lodash": "~3.10.1",
     "ms": "~0.7.1",


### PR DESCRIPTION
Snyk identified a security problem with `debug` version 2.2.0, so update to the latest 2.x which not longer has the security risk.  https://snyk.io/test/npm/debug/2.2.0

Also update `ms` to 2.0.0 because of a similar issue https://snyk.io/test/npm/ms/0.7.1