### PR TITLE
env argument added to init method

### DIFF
--- a/lib/monitor.js
+++ b/lib/monitor.js
@@ -22,21 +22,22 @@ switch(os.arch()){
 process.once('SIGUSR2', function () {
   paused = !paused;
 });
+module.exports = function monit (worker, debug, fork, env) {
+  env = env || process.env;
 
-module.exports = function monit (worker, debug, fork) {
   var proc = worker.process;
   var failures_cpu = 0;
   var failures_mem = 0;
   var monitor;
 
-  var max_mem_failures = parseInt(process.env.MEM_MONITOR_FAILURES, 10) || 10;
-  var max_cpu_failures = parseInt(process.env.CPU_MONITOR_FAILURES, 10) || 10;
+  var max_mem_failures = parseInt(env.MEM_MONITOR_FAILURES, 10) || 10;
+  var max_cpu_failures = parseInt(env.CPU_MONITOR_FAILURES, 10) || 10;
   var max_memory = DEFAULT_MAX_MEMORY;
-  var max_kill_timeout = parseInt(process.env.MAX_KILL_TIMEOUT, 10) || 5000;
+  var max_kill_timeout = parseInt(env.MAX_KILL_TIMEOUT, 10) || 5000;
 
-  if (process.env.MAX_MEMORY_ALLOWED_MB &&
-    parseInt(process.env.MAX_MEMORY_ALLOWED_MB, 10) > 0){
-    max_memory = bytes(process.env.MAX_MEMORY_ALLOWED_MB + 'mB');
+  if (env.MAX_MEMORY_ALLOWED_MB &&
+    parseInt(env.MAX_MEMORY_ALLOWED_MB, 10) > 0){
+    max_memory = bytes(env.MAX_MEMORY_ALLOWED_MB + 'mB');
   }
 
   var kill_child_and_restart = function (resource) {


### PR DESCRIPTION
This change allows users to run this module using a custom env object instead of the global `process.env` instance.
`process.env` remains as default value if no custom env object was provided.