### PR TITLE
adds proc_util.terminate for consistent & safe worker termination

### DIFF
--- a/lib/monitor.js
+++ b/lib/monitor.js
@@ -3,6 +3,8 @@ var ms        = require('ms');
 var bytes     = require('bytes');
 var os        = require('os');
 
+const proc_util = require('./proc_util');
+
 var paused = false;
 
 // this is pretty arbitrary, but we have no way of knowing what --max-old-space-size is set to
@@ -32,7 +34,6 @@ module.exports = function monit (worker, debug, fork) {
   var max_mem_failures = parseInt(process.env.MEM_MONITOR_FAILURES, 10) || 10;
   var max_cpu_failures = parseInt(process.env.CPU_MONITOR_FAILURES, 10) || 10;
   var max_memory = DEFAULT_MAX_MEMORY;
-  var max_kill_timeout = ms(process.env.MAX_KILL_TIMEOUT || '5 seconds');
 
   if (process.env.MAX_MEMORY_ALLOWED_MB &&
     parseInt(process.env.MAX_MEMORY_ALLOWED_MB, 10) > 0){
@@ -53,18 +54,8 @@ module.exports = function monit (worker, debug, fork) {
         new_pid: new_worker.process.pid
       }));
 
-      worker._worker_terminated = true;
-      process.kill(proc.pid, 'SIGTERM');
-      // after trying SIGTERM, there is a chance it won't work, so
-      // we call SIGKILL to ensure it dies
-      setTimeout(function () {
-        try {
-          process.kill(proc.pid, 'SIGKILL');
-          debug('trying to force kill ' + proc.pid);
-        } catch(e) {
-          debug('proc ' + proc.pid + ' is already dead or can\'t be killed');
-        }
-      }, max_kill_timeout);
+      debug('PID/%s: killing old worker (replaced by %s)', proc.pid, new_worker.process.pid);
+      proc_util.terminate(worker);
     });
   };
 

--- a/lib/proc_util.js
+++ b/lib/proc_util.js
@@ -1,0 +1,32 @@
+const debug = require('debug')('master-process');
+const ms = require('ms');
+
+const MAX_KILL_TIMEOUT = ms(process.env.MAX_KILL_TIMEOUT || '5 seconds');
+
+/**
+ * Terminates the given Worker by first disconnecting it from the cluster, then sending
+ * it a SIGTERM. If the underlying process does not exit by `max_kill_timeout` then it
+ * will follow up with a SIGKILL.
+ *
+ * @param {Worker} worker
+ * @param {number} [max_kill_timeout=5000] time to wait before sending SIGKILL (millis)
+ */
+exports.terminate = function terminate(worker, max_kill_timeout) {
+  const proc = worker.process;
+  const killWith = signal => {
+    try {
+      debug('PID/%s: sending %s', proc.pid, signal);
+      process.kill(proc.pid, signal);
+    } catch (err) {
+      debug("PID/%s: process is already dead or can't be killed: %s", proc.pid, err);
+    }
+  };
+
+  // after trying SIGTERM, there is a chance it won't work, so
+  // we call SIGKILL to ensure it dies
+  const killTimeout = setTimeout(() => killWith('SIGKILL'), max_kill_timeout || MAX_KILL_TIMEOUT);
+  proc.on('exit', () => clearTimeout(killTimeout));
+
+  worker._worker_terminated = true;
+  killWith('SIGTERM');
+};

--- a/test/exit.tests.js
+++ b/test/exit.tests.js
@@ -3,24 +3,28 @@ const assert = require('chai').assert;
 const async = require('async');
 const test_server = require('./fixture/test_server');
 
+const testTimeout = 10000;
+
 describe('cluster exit', function () {
-  this.timeout(10000);
+  this.timeout(testTimeout);
   let proc;
   let worker_pid;
 
-  beforeEach(function (done) {
-    proc = test_server.createCluster((err, worker) => {
-      worker_pid = worker.pid;
-      done(err);
+  function setUpCluster(env) {
+    beforeEach(function (done) {
+      proc = test_server.createCluster(env, (err, worker) => {
+        worker_pid = worker.pid;
+        done(err);
+      });
     });
-  });
 
-  afterEach(function (done) {
-    test_server.destroyCluster(proc, done);
-  });
+    afterEach(function (done) {
+      test_server.destroyCluster(proc, done);
+    });
+  }
 
   describe('when the cluster receives a SIGTERM', function () {
-    it('should exit cleanly', function (done) {
+    const clusterShouldExitCleanly = () => it('should exit cleanly', function (done) {
       proc.kill('SIGTERM');
       proc.once('exit', function (code) {
         assert.equal(code, 0);
@@ -28,10 +32,20 @@ describe('cluster exit', function () {
       });
     });
 
-    it('should allow workers to clean up before killing', function (done) {
-      proc.once('clean_up', () => {
-        done();
-      }).kill('SIGTERM');
+    describe('and the worker exits right away', function () {
+      setUpCluster();
+      clusterShouldExitCleanly();
+
+      it('should allow workers to clean up before killing', function (done) {
+        proc.once('clean_up', () => {
+          done();
+        }).kill('SIGTERM');
+      });
+    });
+
+    describe('and the worker refuses to exit in a timely fashion', function () {
+      setUpCluster({ MAX_KILL_TIMEOUT: '5s', WORKER_EXIT_DELAY: String(testTimeout*2) });
+      clusterShouldExitCleanly();
     });
   });
 
@@ -43,6 +57,8 @@ describe('cluster exit', function () {
       ['due to a SIGKILL', () => process.kill(worker_pid, 'SIGKILL')],
     ].forEach(([desc, crashWorker]) => {
       describe(desc, function () {
+        setUpCluster();
+
         it('should be replaced with a new worker', function (done) {
           crashWorker();
           test_server.onWorkerListening(proc, new_worker => {
@@ -52,24 +68,28 @@ describe('cluster exit', function () {
           });
         });
       });
-
     });
 
-    it('should be replaced at the rate specified by RESTART_DELAY', function (done) {
-      const restartDelay = 1000;
-      const testStartedAt = Date.now();
+    const workerThrottle = 300;
+    describe(`when WORKER_THROTTLE is ${workerThrottle}`, function () {
+      setUpCluster({ WORKER_THROTTLE: String(workerThrottle) });
 
-      async.series([
-        cb => request.get('http://localhost:9898/exit', () => cb(null)),
-        cb => test_server.onWorkerListening(proc, () => cb(null, Date.now())),
-        cb => request.get('http://localhost:9898/crash', () => cb(null)),
-        cb => test_server.onWorkerListening(proc, () => cb(null, Date.now())),
-      ], (err, [, worker1_startedAt, , worker2_startedAt]) => {
-        assert.closeTo(worker1_startedAt, testStartedAt + restartDelay, 100, `+${worker1_startedAt - testStartedAt}ms delay on worker1`);
-        assert.closeTo(worker2_startedAt, worker1_startedAt + restartDelay, 100, `+${worker2_startedAt - worker1_startedAt}ms delay on worker2`);
-        done();
+      it('should be replaced at the rate specified by WORKER_THROTTLE', function (done) {
+        const testStartedAt = Date.now();
+
+        async.series([
+          cb => request.get('http://localhost:9898/exit', () => cb(null)),
+          cb => test_server.onWorkerListening(proc, () => cb(null, Date.now())),
+          cb => request.get('http://localhost:9898/crash', () => cb(null)),
+          cb => test_server.onWorkerListening(proc, () => cb(null, Date.now())),
+        ], (err, [, worker1_startedAt, , worker2_startedAt]) => {
+          assert.closeTo(worker1_startedAt, testStartedAt + workerThrottle, 100, `+${worker1_startedAt - testStartedAt}ms delay on worker1`);
+          assert.closeTo(worker2_startedAt, worker1_startedAt + workerThrottle, 100, `+${worker2_startedAt - worker1_startedAt}ms delay on worker2`);
+          done();
+        });
       });
     });
+
   });
 
 });

--- a/test/fixture/server.js
+++ b/test/fixture/server.js
@@ -1,4 +1,5 @@
 const cluster = require('cluster');
+const ms = require('ms');
 
 if (cluster.isMaster) {
   const mp = require('../../');
@@ -22,7 +23,7 @@ function exitWorker() {
     // simulate some cleanup that has to happen before exiting
     sendEvent('clean_up');
     process.exit(0);
-  });
+  }, ms(process.env.WORKER_EXIT_DELAY || 0));
 }
 
 sendEvent('starting');

--- a/test/fixture/test_server.js
+++ b/test/fixture/test_server.js
@@ -4,11 +4,20 @@ const request = require('request');
 /**
  * Creates a new master-process cluster for use in tests.
  *
+ * @param {object} [env={}] environment variables to be passed to the server
  * @param {function} cb invoked once the cluster is online
  * @return {ChildProcess} the master process of the cluster
  */
-function createCluster(cb) {
-  const proc = spawn(process.execPath, [__dirname + '/server.js']);
+function createCluster(env, cb) {
+  if (typeof env === 'function') {
+    cb = env;
+    env = {};
+  }
+
+  const proc = spawn(process.execPath, [__dirname + '/server.js'], { env: Object.assign({
+      WORKER_THROTTLE: '0ms', // don't throttle during test execution
+    }, env)
+  });
 
   // //Useful to debug a test
   // proc.stdout.pipe(process.stdout);

--- a/test/reload.tests.js
+++ b/test/reload.tests.js
@@ -1,49 +1,100 @@
+const async = require('async');
 const assert = require('chai').assert;
+
 const test_server = require('./fixture/test_server');
+const { isRunning } = require('./utils');
+
+const testTimeout = 10000;
 
 describe('cluster reload', function () {
-  this.timeout(10000);
+  this.timeout(testTimeout);
   let proc;
 
-  beforeEach(function (done) {
-    proc = test_server.createCluster(done);
-  });
+  function setUpCluster(env) {
+    beforeEach(function (done) {
+      proc = test_server.createCluster(env, done);
+    });
 
-  afterEach(function (done) {
-    test_server.destroyCluster(proc, done);
-  });
+    afterEach(function (done) {
+      test_server.destroyCluster(proc, done);
+    });
+  }
 
-  describe('environment variables', function() {
+  describe('environment variables', function () {
+    setUpCluster();
+
     let envs;
 
-    beforeEach(function(done) {
+    beforeEach(function (done) {
       test_server.onWorkerListening(proc, () => {
         test_server.getWorkerProcessEnv((err, body) => {
-          if (err) { return done(err); }
+          if (err) {
+            return done(err);
+          }
           envs = body.env;
           done();
         });
       }).kill('SIGHUP');
     });
 
-    it('worker env should contain RELOAD_INDEX', function() {
+    it('worker env should contain RELOAD_INDEX', function () {
       assert.equal(envs.RELOAD_INDEX, 1);
     });
 
-    it('worker env should contain WORKER_INDEX', function() {
+    it('worker env should contain WORKER_INDEX', function () {
       assert.equal(envs.WORKER_INDEX, 0);
     });
 
-    it('worker env should contain PPID', function() {
+    it('worker env should contain PPID', function () {
       assert.equal(envs.PPID, proc.pid);
     });
   });
 
   describe('when the cluster receives a SIGHUP', function () {
-    it('should wait for workers to clean up', function (done) {
+    const workerCanCleanUp = () => it('should wait for workers to clean up', function (done) {
       proc.once('clean_up', () => {
         done();
       }).kill('SIGTERM');
+    });
+
+    const workerShouldBeReplaced = () => it('should be replaced with a new worker', function (done) {
+      test_server.getWorkerProcessEnv((err, { pid: oldWorkerPid }) => {
+        if (err) {
+          return done(err);
+        }
+
+        async.parallel([
+          cb => test_server.onWorkerListening(proc, newWorker => cb(null, newWorker)),
+          cb => async.retry({ times: 9, interval: testTimeout / 10 }, isWorkerDead, cb),
+          cb => cb(null, proc.kill('SIGHUP')), // <= trigger cluster reload
+        ], (err, [{ pid: newWorkerPid }]) => {
+          assert.isNull(err);
+          assert.isNumber(newWorkerPid);
+          assert.notEqual(newWorkerPid, oldWorkerPid);
+          done();
+        });
+
+        function isWorkerDead(cb) {
+          if (isRunning(oldWorkerPid)) {
+            cb(Error('worker still alive: ' + oldWorkerPid));
+          } else {
+            cb(null);
+          }
+        }
+      });
+    });
+
+    describe('when the worker exits', function () {
+      setUpCluster();
+
+      workerCanCleanUp();
+      workerShouldBeReplaced();
+    });
+
+    describe('when the worker refuses to exit', function () {
+      setUpCluster({ WORKER_EXIT_DELAY: String(testTimeout*2) });
+
+      workerShouldBeReplaced();
     });
   });
 

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,0 +1,16 @@
+/**
+ * @param {number} pid
+ * @return {boolean} true if the process with the given PID is running
+ */
+function isRunning(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (e) {
+    return false;
+  }
+}
+
+module.exports = {
+  isRunning
+};


### PR DESCRIPTION
Added `proc_utils.terminate` so that we always follow the same protocol when killing workers:

1. send a `SIGTERM`,
1. wait for `process.env.MAX_KILL_TIMEOUT`, and then
1. send a `SIGKILL`.

This prevents runaway workers from messing with cluster reload an shutdown, which could happen previously. Catch any exceptions from `process.kill`, which occurs if the process is already gone (fixes #11).