### PR TITLE
Ensures that only old workers are removed to avoid race conditions

### DIFF
--- a/index.js
+++ b/index.js
@@ -64,7 +64,7 @@ function fork (worker_index, reload_counter, callback) {
 
     _.values(cluster.workers)
     .filter(function (worker) {
-      return worker._reload_counter !== reload_counter;
+      return worker._reload_counter < reload_counter;
     })
     .forEach(function (old_worker) {
       var old_proc = old_worker.process;

--- a/index.js
+++ b/index.js
@@ -64,7 +64,7 @@ function fork (worker_index, reload_counter, callback) {
 
     _.values(cluster.workers)
     .filter(function (worker) {
-      return worker._reload_counter < reload_counter;
+      return worker._reload_counter < reload_counter && worker._worker_index === worker_index;
     })
     .forEach(function (old_worker) {
       var old_proc = old_worker.process;

--- a/test/fixture/server.js
+++ b/test/fixture/server.js
@@ -58,12 +58,20 @@ const server = http.createServer(function (req, res) {
   res.end(process.env.RELOAD_INDEX);
 });
 
-server.listen(process.env.PORT || 9898, function (err) {
-  if (err) {
-    console.error(err);
-    return process.exit(1);
-  }
-  sendEvent('listening');
-});
+function listen() {
+  sendEvent('listen');
+  server.listen(process.env.PORT || 9898, function (err) {
+    if (err) {
+      console.error(err);
+      return process.exit(1);
+    }
+    sendEvent('listening');
+  });
+}
 
+if (process.RELOAD_INDEX != 0 && process.env.DELAY_LISTEN) {
+  setTimeout(listen, parseFloat(process.env.WORKER_INDEX) * parseFloat(process.env.DELAY_LISTEN));
+} else {
+  listen();
+}
 process.on('SIGTERM', exitWorker);

--- a/test/fixture/server.js
+++ b/test/fixture/server.js
@@ -3,6 +3,7 @@ const ms = require('ms');
 
 if (cluster.isMaster) {
   const mp = require('../../');
+  process.on('SIGHUP', () => sendEvent('reload'));
   return mp.init();
 }
 

--- a/test/fixture/test_server.js
+++ b/test/fixture/test_server.js
@@ -25,13 +25,14 @@ function createCluster(env, cb) {
 
   proc.stdout.on('data', function (data) {
     const marker = 'event:>>';
-    const text = data.toString();
-
-    if (text.indexOf(marker) === 0) {
-      const json = text.substr(marker.length);
-      const { name, payload } = JSON.parse(json);
-      setTimeout(() => proc.emit(name, payload), 50);
-    }
+    const texts = data.toString().split('\n');;
+    texts.forEach(text => {
+      if (text.indexOf(marker) === 0) {
+        const json = text.substr(marker.length);
+        const { name, payload } = JSON.parse(json);
+        setTimeout(() => proc.emit(name, payload), 50);
+      }
+    });
   });
 
   proc.once('exit', function () {


### PR DESCRIPTION
Currently when multiple SIGHUP signals are sent to the master multiple generations of workers kill each other. The change makes sure that a new worker will only remove older generations. 