### PR TITLE
workers improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+<a name="v4.0.0"></a>
+ # v4.0.0
+### Feature
+* Add new `WORKERS=MAX` to use `number of cores` (previously `AUTO`)
+* Add new `MAX_CPU_ALLOWED` to allow control CPU monitor
+### Breaking Changes
+* Change behavior of `WORKERS=AUTO` to `number of cores - 1`
+
 <a name="v3.0.0"></a>
  # v3.0.0
 ### Feature

--- a/README.md
+++ b/README.md
@@ -50,9 +50,10 @@ The master process handles forking the required number of workers as well as:
 
 ### Number of workers
 
-The number of workers can be controlled with the WORKERS environment variable. The default is `1`.
+The number of workers can be controlled with the `WORKERS` environment variable. The default is `1`.
 
-`WORKERS=AUTO` sets the number of workers equals to the number of cores (as returned by `os.cpus().length`)
+`WORKERS=MAX` sets the number of workers equals to the `number of cores` (as returned by `os.cpus().length`)
+`WORKERS=AUTO` sets the number of workers equals to the `number of cores - 1` (or a single worker if single core)
 
 ### Application Crashes
 
@@ -79,6 +80,14 @@ If the master process detects that the version of the `master-process` module ha
 ### CPU and Memory monitoring
 
 The master process watch by default the behavior of the worker. If the process is taking too much resources it will load a new worker.
+Here are the environment variables that can be used to control the process monitoring and their respective defaults:
+
+```
+MEM_MONITOR_FAILURES=10
+CPU_MONITOR_FAILURE=10
+MAX_MEMORY_ALLOWED_MB=1200
+MAX_CPU_ALLOWED=95
+```
 
 ### SIGUSR2
 

--- a/index.js
+++ b/index.js
@@ -11,9 +11,17 @@ const proc_util = require('./lib/proc_util');
 
 var cwd     = process.cwd();
 
-var DESIRED_WORKERS = process.env.WORKERS === 'AUTO' ?
-                        os.cpus().length :
-                        parseInt(process.env.WORKERS || 1) || 1;
+var maxCpus = os.cpus().length;
+var autoCpus = maxCpus > 1 ? maxCpus - 1 : 1;
+
+var DESIRED_WORKERS;
+if (process.env.WORKERS === 'MAX') {
+  DESIRED_WORKERS = maxCpus;
+} else if (process.env.WORKERS === 'AUTO') {
+  DESIRED_WORKERS = autoCpus;
+} else {
+  DESIRED_WORKERS = parseInt(process.env.WORKERS || 1, 10) || 1;
+}
 
 const WORKER_THROTTLE = typeof process.env.WORKER_THROTTLE === 'string' ? ms(process.env.WORKER_THROTTLE) : ms('1 second');
 

--- a/lib/monitor.js
+++ b/lib/monitor.js
@@ -34,6 +34,7 @@ module.exports = function monit (worker, debug, fork) {
   var max_mem_failures = parseInt(process.env.MEM_MONITOR_FAILURES, 10) || 10;
   var max_cpu_failures = parseInt(process.env.CPU_MONITOR_FAILURES, 10) || 10;
   var max_memory = DEFAULT_MAX_MEMORY;
+  var max_cpu = parseInt(process.env.MAX_CPU_ALLOWED, 10) || 95;
 
   if (process.env.MAX_MEMORY_ALLOWED_MB &&
     parseInt(process.env.MAX_MEMORY_ALLOWED_MB, 10) > 0){
@@ -121,7 +122,7 @@ module.exports = function monit (worker, debug, fork) {
           }));
         }
 
-        if (result.cpu > 95) {
+        if (result.cpu > max_cpu) {
           failures_cpu++;
           debug('PID/%s: too much CPU used  %s - failures %s', proc.pid, result.cpu.toFixed(), failures_cpu);
           if (failures_cpu === max_cpu_failures) {


### PR DESCRIPTION
# Changes

`WORKERS=MAX` sets the number of workers equals to the `number of cores` (as returned by `os.cpus().length`)
`WORKERS=AUTO` sets the number of workers equals to the `number of cores - 1` (or a single worker if single core)
`MAX_CPU_ALLOWED` to allow control CPU monitor (default 95)
